### PR TITLE
Restore OpenAI integration API and add mock vector store

### DIFF
--- a/integrations/direct_openai.py
+++ b/integrations/direct_openai.py
@@ -7,6 +7,7 @@ from openai import OpenAI
 import json
 import re
 from datetime import datetime
+from types import SimpleNamespace
 from core.memory_engine import Memory, MemoryEngine
 from core.logging_config import get_logger, monitor_performance
 from .embeddings import OpenAIEmbeddings
@@ -37,6 +38,14 @@ class DirectOpenAIChat:
         
         # Load optimized system prompt
         self.base_system_prompt = self._load_system_prompt()
+
+        # Simple context builder for backwards compatibility
+        self.context_builder = SimpleNamespace(
+            build_context=lambda **kwargs: ""
+        )
+
+        # Track how many messages were sent to OpenAI for debugging
+        self.last_messages_count = 0
         
         # User identity profile for GPT-4o personalization
         self.user_identity = {
@@ -479,6 +488,9 @@ You are currently supporting a user named Jeremy Kimble, an IT consultant who is
             user_message=message,
             system_prompt=system_prompt
         )
+
+        # Record how many messages were sent for external inspection
+        self.last_messages_count = len(messages)
         
         try:
             # GPT-4o optimized API call with human-like tuning
@@ -538,10 +550,39 @@ You are currently supporting a user named Jeremy Kimble, an IT consultant who is
                 )
             
             return assistant_response, messages
-            
+
         except Exception as e:
             self.logger.error(f"OpenAI API error: {e}", exc_info=True)
             raise
+
+    # ------------------------------------------------------------------
+    # Backwards compatibility helpers
+    # ------------------------------------------------------------------
+    def chat_with_memory(
+        self,
+        message: str,
+        system_prompt: Optional[str] = None,
+        include_recent: int = 5,
+        include_relevant: int = 5,
+        remember_response: bool = True,
+    ) -> str:
+        """Compatibility wrapper mimicking the older OpenAIIntegration API.
+
+        Older versions of the project exposed a ``chat_with_memory`` method
+        which accepted ``include_recent`` and ``include_relevant`` parameters.
+        The refactored implementation collapsed this into the ``chat`` method
+        which automatically handles context.  This wrapper simply delegates to
+        :meth:`chat` while ignoring the extra parameters so that existing code
+        continues to function.
+        """
+
+        response, _ = self.chat(
+            message=message,
+            thread_id="default",
+            system_prompt=system_prompt,
+            remember_response=remember_response,
+        )
+        return response
     
     def get_conversation_history(self, thread_id: str) -> List[Dict[str, str]]:
         """Get full conversation history for a thread"""

--- a/storage/mock_store.py
+++ b/storage/mock_store.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+"""Simple in-memory vector store used for tests.
+
+This module provides a minimal :class:`MockVectorStore` that implements the
+subset of the :class:`~core.memory_engine.VectorStore` interface required by the
+unit tests.  It allows tests to run without requiring an actual vector database
+backend.
+"""
+
+from typing import List
+from core.memory_engine import Memory, VectorStore
+
+
+class MockVectorStore(VectorStore):
+    """A trivial vector store that keeps memories in a list."""
+
+    def __init__(self) -> None:
+        self.memories: List[Memory] = []
+
+    def add_memory(self, memory: Memory) -> str:
+        self.memories.append(memory)
+        # Use list index as identifier
+        return str(len(self.memories) - 1)
+
+    def search(self, query_embedding, k: int = 5) -> List[Memory]:
+        # Return up to ``k`` memories in FIFO order; no similarity used
+        return self.memories[:k]
+
+    def delete_memory(self, memory_id: str) -> bool:
+        try:
+            idx = int(memory_id)
+            self.memories.pop(idx)
+            return True
+        except Exception:
+            return False
+
+    def clear_all(self) -> None:
+        self.memories.clear()


### PR DESCRIPTION
## Summary
- reinstate `get_openai_integration` dependency and update chat endpoint to call `chat_with_memory`
- add explicit OPTIONS preflight handler for CORS tests
- provide compatibility wrapper and context builder in `DirectOpenAIChat`
- supply minimal `MockVectorStore` for tests

## Testing
- `pytest tests/test_api.py -q`
- `pytest test_api_key.py -q` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68995490561083339a0d918a51b01e8a