### PR TITLE
feat: render markdown with highlighted code blocks

### DIFF
--- a/web_interface_enhanced.html
+++ b/web_interface_enhanced.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Memory Layer - Enhanced Chat</title>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Memory Layer - Enhanced Chat</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <style>
         :root {
             /* Light theme */
@@ -492,6 +495,43 @@
             0%, 100% { height: 20px; }
             50% { height: 10px; }
         }
+
+        /* Code block styling */
+        pre {
+            background: var(--bg-tertiary);
+            padding: 12px;
+            border-radius: 8px;
+            overflow-x: auto;
+            position: relative;
+        }
+
+        pre code {
+            display: block;
+            background: none;
+            padding: 0;
+            line-height: 1.5;
+        }
+
+        .copy-btn {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border-primary);
+            color: var(--text-secondary);
+            padding: 2px 6px;
+            font-size: 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            opacity: 0.7;
+            transition: opacity 0.2s;
+        }
+
+        .copy-btn:hover {
+            opacity: 1;
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+        }
     </style>
 </head>
 <body data-theme="light">
@@ -908,16 +948,16 @@
             const messagesContainer = document.getElementById('messages');
             const messageDiv = document.createElement('div');
             messageDiv.className = `message ${sender}`;
-            
+
             // Generate unique ID for message if not provided
             if (!messageId) {
                 messageId = `msg_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
             }
             messageDiv.id = messageId;
-            
+
             const time = new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
             const avatar = sender === 'user' ? '👤' : '🧠';
-            
+
             let actionsHTML = '';
             if (sender === 'assistant') {
                 actionsHTML = `
@@ -931,26 +971,43 @@
                     </div>
                 `;
             }
-            
+
+            const parsedContent = marked.parse(content);
+
             messageDiv.innerHTML = `
                 <div class="message-avatar">${avatar}</div>
                 <div class="message-content">
-                    <div class="message-text">${content}</div>
+                    <div class="message-text">${parsedContent}</div>
                     <div class="message-time">${time}</div>
                     ${actionsHTML}
                 </div>
             `;
-            
+
             messagesContainer.appendChild(messageDiv);
+            hljs.highlightAll();
+
+            messageDiv.querySelectorAll('pre').forEach(pre => {
+                const copyBtn = document.createElement('button');
+                copyBtn.className = 'copy-btn';
+                copyBtn.textContent = 'Copy';
+                copyBtn.addEventListener('click', () => {
+                    const code = pre.querySelector('code');
+                    navigator.clipboard.writeText(code.innerText);
+                    copyBtn.textContent = 'Copied!';
+                    setTimeout(() => copyBtn.textContent = 'Copy', 2000);
+                });
+                pre.appendChild(copyBtn);
+            });
+
             messagesContainer.scrollTop = messagesContainer.scrollHeight;
-            
+
             // Track message for conversation history
             currentMessages.push({
                 sender: sender,
                 content: content,
                 timestamp: new Date().toISOString()
             });
-            
+
             // Generate title after we have enough context (2+ exchanges)
             if (currentMessages.length >= 3 && currentMessages.length <= 4 && sender === 'assistant') {
                 console.log('Triggering title generation with', currentMessages.length, 'messages');


### PR DESCRIPTION
## Summary
- render incoming messages as markdown
- apply highlight.js to code blocks and add copy buttons
- style code blocks for better readability

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'storage.mock_store'; ImportError: cannot import name 'get_openai_integration'; ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_68996603cadc8333a52e82336eb726b5