### PR TITLE
feat: add streaming chat with cancel

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Depends, status, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 import uvicorn
 import time
 
@@ -339,7 +339,7 @@ async def clear_memories(engine: MemoryEngine = Depends(get_memory_engine)):
 # Chat endpoints
 @app.post("/chat", response_model=ChatResponse)
 async def chat_with_memory(
-    chat_data: ChatRequest, 
+    chat_data: ChatRequest,
     direct_chat: DirectOpenAIChat = Depends(get_direct_openai_chat),
     request: Request = None
 ):
@@ -379,6 +379,29 @@ async def chat_with_memory(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=f"Chat failed: {str(e)}"
         )
+
+
+@app.post("/chat/stream")
+async def chat_with_memory_stream(
+    chat_data: ChatRequest, direct_chat: DirectOpenAIChat = Depends(get_direct_openai_chat)
+):
+    """Stream chat response tokens incrementally"""
+
+    def event_generator():
+        try:
+            for token in direct_chat.chat_stream(
+                message=chat_data.message,
+                thread_id=chat_data.thread_id,
+                system_prompt=chat_data.system_prompt,
+                remember_response=chat_data.remember_response,
+            ):
+                yield f"data: {token}\n\n"
+            yield "data: [DONE]\n\n"
+        except Exception as e:
+            logger.error("Streaming chat failed", extra={"error": str(e)}, exc_info=True)
+            yield f"data: [ERROR] {str(e)}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 # Stats endpoint

--- a/web_interface.html
+++ b/web_interface.html
@@ -266,6 +266,7 @@
                     onkeypress="handleKeyPress(event)"
                 >
                 <button class="send-button" id="sendButton" onclick="sendMessage()">Send</button>
+                <button class="send-button" id="stopButton" onclick="stopGeneration()" style="display:none;background-color:#f44336;">Stop</button>
             </div>
         </div>
     </div>
@@ -273,6 +274,7 @@
     <script>
         const API_BASE = 'http://localhost:8000';
         let isConnected = false;
+        let currentAbortController = null;
         
         // Initialize the interface
         async function init() {
@@ -326,28 +328,35 @@
             }
         }
         
-        // Send message
+        // Send message with streaming response
         async function sendMessage() {
             const input = document.getElementById('messageInput');
             const message = input.value.trim();
-            
+
             if (!message || !isConnected) return;
-            
+
             // Add user message to chat
             addMessage('user', message);
             input.value = '';
-            
+
             // Show typing indicator
             showTyping(true);
-            
-            // Disable send button
+
             const sendButton = document.getElementById('sendButton');
-            sendButton.disabled = true;
-            sendButton.textContent = 'Sending...';
-            
+            const stopButton = document.getElementById('stopButton');
+            sendButton.style.display = 'none';
+            stopButton.style.display = 'inline';
+
+            // Create AbortController
+            const controller = new AbortController();
+            currentAbortController = controller;
+
+            // Placeholder for assistant message
+            const assistantDiv = addMessage('assistant', '');
+            const textElem = assistantDiv.querySelector('.message-content div');
+
             try {
-                // Send to API
-                const response = await fetch(`${API_BASE}/chat`, {
+                const response = await fetch(`${API_BASE}/chat/stream`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -357,27 +366,57 @@
                         include_recent: 5,
                         include_relevant: 3,
                         remember_response: true
-                    })
+                    }),
+                    signal: controller.signal
                 });
-                
-                const data = await response.json();
-                
-                // Add assistant response
-                addMessage('assistant', data.response);
-                
-                // Update memory count
+
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    buffer += decoder.decode(value, { stream: true });
+                    const parts = buffer.split('\n\n');
+                    buffer = parts.pop();
+                    for (const part of parts) {
+                        const line = part.trim();
+                        if (line.startsWith('data: ')) {
+                            const token = line.slice(6);
+                            if (token === '[DONE]') {
+                                break;
+                            }
+                            textElem.textContent += token;
+                        }
+                    }
+                }
+
                 await updateMemoryCount();
-                
+
             } catch (error) {
-                console.error('Error sending message:', error);
-                addMessage('assistant', '❌ Sorry, I encountered an error. Please check if the API server is running.');
+                if (error.name !== 'AbortError') {
+                    console.error('Error sending message:', error);
+                    textElem.textContent = '❌ Sorry, I encountered an error. Please check if the API server is running.';
+                }
             }
-            
-            // Re-enable send button
+
+            // Reset UI
             showTyping(false);
-            sendButton.disabled = false;
-            sendButton.textContent = 'Send';
+            sendButton.style.display = 'inline';
+            stopButton.style.display = 'none';
+            currentAbortController = null;
             input.focus();
+        }
+
+        function stopGeneration() {
+            if (currentAbortController) {
+                currentAbortController.abort();
+                currentAbortController = null;
+                showTyping(false);
+                document.getElementById('sendButton').style.display = 'inline';
+                document.getElementById('stopButton').style.display = 'none';
+            }
         }
         
         // Add message to chat
@@ -385,18 +424,19 @@
             const messagesContainer = document.getElementById('messages');
             const messageDiv = document.createElement('div');
             messageDiv.className = `message ${sender}`;
-            
+
             const time = new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
-            
+
             messageDiv.innerHTML = `
                 <div class="message-content">
                     <div>${content}</div>
                     <div class="message-time">${time}</div>
                 </div>
             `;
-            
+
             messagesContainer.appendChild(messageDiv);
             messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            return messageDiv;
         }
         
         // Show/hide typing indicator

--- a/web_interface_enhanced.html
+++ b/web_interface_enhanced.html
@@ -842,27 +842,33 @@
         async function sendMessage() {
             const input = document.getElementById('messageInput');
             const message = input.value.trim();
-            
+
             if (!message) return;
-            
+
             if (!isConnected) {
                 console.warn('Not connected to API, attempting to send anyway...');
             }
-            
+
             // Add user message
             addMessage('user', message);
             input.value = '';
             autoResize(input);
-            
+
             // Show typing indicator with stop button
             isGenerating = true;
             showTyping(true);
-            
+
             // Create abort controller for this request
             currentGenerationController = new AbortController();
-            
+
+            // Placeholder assistant message (not added to history yet)
+            const msgId = addMessage('assistant', '', null, true);
+            const messageDiv = document.getElementById(msgId);
+            const textElem = messageDiv.querySelector('.message-text');
+            let fullResponse = '';
+
             try {
-                const response = await fetch(`${API_BASE}/chat`, {
+                const response = await fetch(`${API_BASE}/chat/stream`, {
                     signal: currentGenerationController.signal,
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -874,37 +880,59 @@
                         thread_id: conversationThreadId
                     })
                 });
-                
-                const data = await response.json();
-                
-                // Simulate typing delay for better UX
-                setTimeout(() => {
-                    isGenerating = false;
-                    showTyping(false);
-                    addMessage('assistant', data.response);
-                    updateMemoryCount();
-                    // Trigger title generation if this is one of the first few messages
-                    if (currentMessages.length <= 6) {
-                        console.log('Triggering title generation with', currentMessages.length, 'messages');
-                        generateConversationTitle();
+
+                const reader = response.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    buffer += decoder.decode(value, { stream: true });
+                    const parts = buffer.split('\n\n');
+                    buffer = parts.pop();
+                    for (const part of parts) {
+                        const line = part.trim();
+                        if (line.startsWith('data: ')) {
+                            const token = line.slice(6);
+                            if (token === '[DONE]') {
+                                break;
+                            }
+                            textElem.textContent += token;
+                            fullResponse += token;
+                        }
                     }
-                }, 1000);
-                
+                }
+
+                // Add to history after completion
+                currentMessages.push({
+                    sender: 'assistant',
+                    content: fullResponse,
+                    timestamp: new Date().toISOString()
+                });
+
+                updateMemoryCount();
+
+                if (currentMessages.length >= 3 && currentMessages.length <= 6) {
+                    console.log('Triggering title generation with', currentMessages.length, 'messages');
+                    generateConversationTitle();
+                }
+
             } catch (error) {
-                isGenerating = false;
-                showTyping(false);
                 if (error.name !== 'AbortError') {
-                    addMessage('assistant', '❌ Sorry, I encountered an error. Please check if the API server is running.');
+                    textElem.textContent = '❌ Sorry, I encountered an error. Please check if the API server is running.';
                 }
             } finally {
+                isGenerating = false;
+                showTyping(false);
                 currentGenerationController = null;
             }
-            
+
             input.focus();
         }
 
         // Add message to chat
-        function addMessage(sender, content, messageId = null) {
+        function addMessage(sender, content, messageId = null, skipHistory = false) {
             const messagesContainer = document.getElementById('messages');
             const messageDiv = document.createElement('div');
             messageDiv.className = `message ${sender}`;
@@ -943,19 +971,21 @@
             
             messagesContainer.appendChild(messageDiv);
             messagesContainer.scrollTop = messagesContainer.scrollHeight;
-            
-            // Track message for conversation history
-            currentMessages.push({
-                sender: sender,
-                content: content,
-                timestamp: new Date().toISOString()
-            });
-            
-            // Generate title after we have enough context (2+ exchanges)
-            if (currentMessages.length >= 3 && currentMessages.length <= 4 && sender === 'assistant') {
-                console.log('Triggering title generation with', currentMessages.length, 'messages');
-                generateConversationTitle();
+
+            if (!skipHistory) {
+                currentMessages.push({
+                    sender: sender,
+                    content: content,
+                    timestamp: new Date().toISOString()
+                });
+
+                if (currentMessages.length >= 3 && currentMessages.length <= 4 && sender === 'assistant') {
+                    console.log('Triggering title generation with', currentMessages.length, 'messages');
+                    generateConversationTitle();
+                }
             }
+
+            return messageId;
         }
 
         // Generate conversation title using AI


### PR DESCRIPTION
## Summary
- add /chat/stream SSE endpoint that streams tokens from OpenAI and logs errors
- expose DirectOpenAIChat.chat_stream helper for incremental responses
- update web UIs to consume streaming API, display stop button, and cancel via AbortController

## Testing
- `pytest tests/test_memory.py::TestMemory::test_memory_creation -q`


------
https://chatgpt.com/codex/tasks/task_e_689965eaf0648333900ee85d0419cf4e