### PR TITLE
Enable FAISS index vector deletion with persistence

### DIFF
--- a/storage/faiss_store.py
+++ b/storage/faiss_store.py
@@ -1,3 +1,8 @@
+from typing import List, Dict, Any, Optional
+import pickle
+import os
+from core.memory_engine import Memory, VectorStore
+
 # Try to import numpy and faiss, fall back to mock if not available
 try:
     import numpy as np
@@ -30,38 +35,70 @@ except ImportError:
     FAISS_AVAILABLE = False
 
     # Mock faiss for compatibility
+    class MockIndex:
+        """Simple in-memory mock for FAISS indices"""
+
+        def __init__(self, dim: int = 0):
+            self.d = dim
+            self.vectors: Dict[int, Any] = {}
+
+        @property
+        def ntotal(self) -> int:
+            return len(self.vectors)
+
+        def add_with_ids(self, vectors, ids):
+            for vec, idx in zip(vectors, ids):
+                self.vectors[int(idx)] = vec
+
+        def search(self, query, k):
+            ids = list(self.vectors.keys())[:k]
+            distances = [[0.0] * len(ids)]
+            return distances, [ids]
+
+        def remove_ids(self, ids):
+            removed = 0
+            for idx in ids:
+                if int(idx) in self.vectors:
+                    del self.vectors[int(idx)]
+                    removed += 1
+            return removed
+
+        def reset(self):
+            self.vectors = {}
+
     class MockFaiss:
         METRIC_L2 = 1
 
         @staticmethod
         def IndexFlatL2(dim):
-            return MockIndex()
+            return MockIndex(dim)
 
-    class MockIndex:
-        def __init__(self):
-            self.ntotal = 0
-            self.d = 0
+        @staticmethod
+        def IndexIDMap(base_index):
+            return base_index
 
-        def add(self, vectors):
-            pass
+        @staticmethod
+        def write_index(index, path):
+            with open(path, "wb") as f:
+                pickle.dump(index, f)
 
-        def search(self, query, k):
-            return [[]], [[]]
-
-        def reset(self):
-            pass
+        @staticmethod
+        def read_index(path):
+            with open(path, "rb") as f:
+                return pickle.load(f)
 
     faiss = MockFaiss()
-from typing import List, Dict, Any, Optional
-import pickle
-import os
-from core.memory_engine import Memory, VectorStore
 
 
 class FaissVectorStore(VectorStore):
     def __init__(self, dimension: int = 1536, index_path: Optional[str] = None):
         self.dimension = dimension
-        self.index = faiss.IndexFlatL2(dimension)
+        base_index = faiss.IndexFlatL2(dimension)
+        try:
+            self.index = faiss.IndexIDMap(base_index)
+        except AttributeError:
+            # Fallback for mock faiss which directly returns base_index
+            self.index = base_index
         self.memories: Dict[int, Memory] = {}
         self.current_id = 0
         self.index_path = index_path
@@ -76,10 +113,18 @@ class FaissVectorStore(VectorStore):
             )
 
         embedding = memory.embedding.astype("float32").reshape(1, -1)
-        self.index.add(embedding)
 
-        memory_id = str(self.current_id)
-        self.memories[self.current_id] = memory
+        memory_id_int = self.current_id
+        ids = np.array([memory_id_int], dtype="int64")
+
+        if hasattr(self.index, "add_with_ids"):
+            self.index.add_with_ids(embedding, ids)
+        else:
+            # Fallback for mock index
+            self.index.add(embedding)
+
+        memory_id = str(memory_id_int)
+        self.memories[memory_id_int] = memory
         self.current_id += 1
 
         if self.index_path:
@@ -110,6 +155,14 @@ class FaissVectorStore(VectorStore):
             idx = int(memory_id)
             if idx in self.memories:
                 del self.memories[idx]
+
+                if hasattr(self.index, "remove_ids"):
+                    ids = np.array([idx], dtype="int64")
+                    self.index.remove_ids(ids)
+
+                if self.index_path:
+                    self.save_index(self.index_path)
+
                 return True
         except ValueError:
             pass


### PR DESCRIPTION
## Summary
- Use `IndexIDMap` to allow FAISS vector deletion and persist updated indices
- Extend storage tests to verify removed memories disappear from search results and persist after reload
- Tidy Chroma vector store to support optional persistence and metadata for testing

## Testing
- `pytest tests/test_storage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689962a09ea88333be60abc090b43df4