### PR TITLE
Use app.state for FastAPI dependencies

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ FastAPI REST API for AI Memory Layer
 """
 
 import os
-from typing import List, Optional
+from typing import List
 from datetime import datetime
 from contextlib import asynccontextmanager
 
@@ -37,10 +37,6 @@ from .models import (
 )
 
 
-# Global variables for dependency injection
-memory_engine: Optional[MemoryEngine] = None
-direct_openai_chat: Optional[DirectOpenAIChat] = None
-memory_manager: Optional[MemoryManager] = None
 logger = get_logger("api")
 
 
@@ -48,15 +44,14 @@ logger = get_logger("api")
 async def lifespan(app: FastAPI):
     """Application lifespan manager"""
     # Startup
-    await startup_event()
+    await startup_event(app)
     yield
     # Shutdown
-    await shutdown_event()
+    await shutdown_event(app)
 
 
-async def startup_event():
+async def startup_event(app: FastAPI):
     """Initialize the memory system on startup"""
-    global memory_engine, direct_openai_chat, memory_manager
 
     try:
         logger.info("Starting AI Memory Layer API initialization")
@@ -99,23 +94,22 @@ async def startup_event():
             )
 
         # Initialize memory engine
-        memory_engine = MemoryEngine(
+        app.state.memory_engine = MemoryEngine(
             vector_store=vector_store,
             embedding_provider=embedding_provider,
             persist_path=memory_persist_path,
         )
 
-        
         # Initialize Direct OpenAI Chat (GPT-4o optimized)
-        direct_openai_chat = DirectOpenAIChat(
+        app.state.direct_openai_chat = DirectOpenAIChat(
             api_key=api_key,
-            memory_engine=memory_engine,
+            memory_engine=app.state.memory_engine,
             model=os.getenv("OPENAI_MODEL", "gpt-4o"),
             system_prompt_path=os.getenv("SYSTEM_PROMPT_PATH", "./prompts/system_prompt_4o.txt"),
         )
 
         # Initialize memory manager
-        memory_manager = create_default_memory_manager(memory_engine)
+        app.state.memory_manager = create_default_memory_manager(app.state.memory_engine)
 
         logger.info(
             "Memory system initialized successfully",
@@ -132,10 +126,11 @@ async def startup_event():
         raise
 
 
-async def shutdown_event():
+async def shutdown_event(app: FastAPI):
     """Cleanup on shutdown"""
     logger.info("API shutdown initiated")
 
+    memory_engine = getattr(app.state, "memory_engine", None)
     if memory_engine and memory_engine.persist_path:
         memory_engine.save_memories()
         logger.info("Memories saved on shutdown")
@@ -186,7 +181,6 @@ async def log_requests(request: Request, call_next):
     return response
 
 
-# Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Configure appropriately for production
@@ -197,34 +191,37 @@ app.add_middleware(
 
 
 # Dependency to get memory engine
-def get_memory_engine() -> MemoryEngine:
-    if not memory_engine:
+def get_memory_engine(request: Request) -> MemoryEngine:
+    engine = getattr(request.app.state, "memory_engine", None)
+    if not engine:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Memory engine not initialized",
         )
-    return memory_engine
+    return engine
 
 
 
 # Dependency to get direct OpenAI chat
-def get_direct_openai_chat() -> DirectOpenAIChat:
-    if not direct_openai_chat:
+def get_direct_openai_chat(request: Request) -> DirectOpenAIChat:
+    chat = getattr(request.app.state, "direct_openai_chat", None)
+    if not chat:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Direct OpenAI chat not initialized",
         )
-    return direct_openai_chat
+    return chat
 
 
 # Dependency to get memory manager
-def get_memory_manager() -> MemoryManager:
-    if not memory_manager:
+def get_memory_manager(request: Request) -> MemoryManager:
+    manager = getattr(request.app.state, "memory_manager", None)
+    if not manager:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Memory manager not initialized",
         )
-    return memory_manager
+    return manager
 
 
 # Exception handler


### PR DESCRIPTION
## Summary
- initialize memory engine, OpenAI chat, and memory manager on `app.state`
- retrieve dependencies from `request.app.state` instead of module globals
- update API tests to set up `app.state` mocks and patched lifespan events

## Testing
- `pytest tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899629d99e88333b74f70a193c509d1