### PR TITLE
Ensure identity corrections are always retrieved

### DIFF
--- a/core/memory_engine.py
+++ b/core/memory_engine.py
@@ -206,16 +206,25 @@ class MemoryEngine:
                                correction.lower() in m.content.lower())]
         
         self.logger.info(f"Adding identity correction: {correction}")
-        return self.add_memory(correction_content, metadata)
+        return self.add_memory(correction_content, metadata, type="correction")
     
     def get_high_priority_memories(self, limit: int = 3) -> List[Memory]:
         """Get high-priority memories (corrections, identity info) for system context"""
-        high_priority = [m for m in self.memories 
+        high_priority = [m for m in self.memories
                         if m.metadata.get("priority") == "high"]
-        
+
         # Sort by recency
         high_priority.sort(key=lambda m: m.timestamp, reverse=True)
         return high_priority[:limit]
+
+    def get_identity_corrections(self) -> List[Memory]:
+        """Retrieve stored identity correction memories."""
+        return [
+            m
+            for m in self.memories
+            if m.metadata.get("type") == "correction"
+            and m.metadata.get("category") == "identity"
+        ]
 
     @monitor_performance("search_memories")
     def search_memories(self, query: str, k: int = 5, include_importance: bool = True) -> List[Memory]:
@@ -275,6 +284,11 @@ class MemoryEngine:
             # Re-sort by new scores and take top k
             results.sort(key=lambda m: m.relevance_score, reverse=True)
             results = results[:k]
+
+        # Always include identity corrections regardless of relevance score
+        for correction in self.get_identity_corrections():
+            if correction not in results:
+                results.append(correction)
 
         log_memory_operation(
             "search", query_length=len(query), results_count=len(results)

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -201,3 +201,19 @@ class TestMemoryEngine:
         contents = [m.content for m in engine2.memories]
         assert "Persistent memory 1" in contents
         assert "Persistent memory 2" in contents
+
+    def test_identity_corrections_search(self, memory_engine):
+        """Identity corrections should be returned regardless of relevance."""
+        correction = memory_engine.add_identity_correction("User's name is Alice")
+        other_memory = memory_engine.add_memory("Some unrelated memory about Python")
+
+        # Simulate vector store search returning only the unrelated memory
+        with patch.object(memory_engine.vector_store, "search", return_value=[other_memory]):
+            results = memory_engine.search_memories("irrelevant query", k=1)
+
+        # Ensure the correction is stored and retrievable
+        corrections = memory_engine.get_identity_corrections()
+        assert correction in corrections
+
+        # Identity correction should be included even though it wasn't in search results
+        assert correction in results


### PR DESCRIPTION
## Summary
- Treat identity correction memories as type `correction` and expose `get_identity_corrections`
- Always append identity corrections to search results
- Add regression test for identity correction search behavior

## Testing
- `pytest tests/test_memory_engine.py::TestMemoryEngine::test_identity_corrections_search -q`
- `pytest tests/test_memory_engine.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'storage.mock_store')*

------
https://chatgpt.com/codex/tasks/task_e_68996295c324833382f381ab639b58d2