### PR TITLE
Add configurable profile query to context builder

### DIFF
--- a/core/context_builder.py
+++ b/core/context_builder.py
@@ -3,9 +3,23 @@ from .memory_engine import MemoryEngine
 
 
 class ContextBuilder:
-    def __init__(self, memory_engine: MemoryEngine, max_context_length: int = 4000):
+    def __init__(
+        self,
+        memory_engine: MemoryEngine,
+        max_context_length: int = 4000,
+        profile_query: Optional[str] = None,
+    ):
+        """Initialize the context builder.
+
+        Args:
+            memory_engine: Engine used for memory retrieval.
+            max_context_length: Maximum length of the returned context string.
+            profile_query: Query used to retrieve persistent profile information.
+                If ``None``, no profile memories are included.
+        """
         self.memory_engine = memory_engine
         self.max_context_length = max_context_length
+        self.profile_query = profile_query
 
     def build_context(
         self,
@@ -14,23 +28,27 @@ class ContextBuilder:
         include_relevant: int = 5,
     ) -> str:
         context_parts = []
-        
-        # Always include user profile information
-        profile_memories = self.memory_engine.search_memories("Jeremy wife Ashley kids dogs age", k=10)
-        important_info = []
-        for memory in profile_memories:
-            if memory.relevance_score > 0.5:
-                important_info.append(memory.content)
-        
-        if important_info:
-            context_parts.append("Key information about Jeremy:")
-            context_parts.extend(important_info[:5])  # Top 5 most relevant
+
+        # Include profile information if a query is provided
+        if self.profile_query:
+            profile_memories = self.memory_engine.search_memories(
+                self.profile_query, k=10
+            )
+            important_info = [
+                memory.content
+                for memory in profile_memories
+                if memory.relevance_score > 0.5
+            ]
+
+            if important_info:
+                context_parts.append("## Profile Information:")
+                context_parts.extend(f"- {info}" for info in important_info[:5])
 
         # Add recent memories
         if include_recent > 0:
             recent_memories = self.memory_engine.get_recent_memories(include_recent)
             if recent_memories:
-                context_parts.append("\nRecent conversations:")
+                context_parts.append("## Recent Context:")
                 for memory in recent_memories:
                     context_parts.append(f"- {memory.content}")
 
@@ -40,10 +58,11 @@ class ContextBuilder:
                 query, include_relevant
             )
             if relevant_memories:
-                context_parts.append(f"\nRelevant to '{query}':")
+                context_parts.append("## Relevant Context:")
                 for memory in relevant_memories:
-                    if memory.relevance_score > 0.6:  # Only high relevance
-                        context_parts.append(f"- {memory.content}")
+                    context_parts.append(
+                        f"- {memory.content} (relevance: {memory.relevance_score:.2f})"
+                    )
 
         # Join and truncate if necessary
         context = "\n".join(context_parts)

--- a/core/memory_engine.py
+++ b/core/memory_engine.py
@@ -361,8 +361,12 @@ class MemoryEngine:
             # Recreate Memory objects
             self.memories = [Memory.from_dict(data) for data in memories_data]
 
-            # Re-add to vector store if available
-            if self.vector_store and self.embedding_provider:
+            # Re-add to vector store if available and not already populated
+            if (
+                self.vector_store
+                and self.embedding_provider
+                and getattr(getattr(self.vector_store, "index", None), "ntotal", 0) == 0
+            ):
                 self.logger.debug("Re-adding memories to vector store")
                 for memory in self.memories:
                     if memory.embedding is None:

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -190,3 +190,26 @@ class TestContextBuilder:
         mock_memory_engine_with_search.search_memories.assert_called_once_with(
             "test query", 2
         )
+
+    def test_profile_memories_included(self):
+        """Profile memories should be included when a profile query is provided"""
+        engine = MemoryEngine()
+        mem = engine.add_memory("Jeremy likes skiing")
+        mem.relevance_score = 0.9
+
+        builder = ContextBuilder(engine, profile_query="Jeremy")
+        context = builder.build_context(include_recent=0, include_relevant=0)
+
+        assert "## Profile Information:" in context
+        assert "Jeremy likes skiing" in context
+
+    def test_profile_memories_excluded_without_query(self):
+        """Profile memories are skipped when no profile query is supplied"""
+        engine = MemoryEngine()
+        mem = engine.add_memory("Jeremy likes skiing")
+        mem.relevance_score = 0.9
+
+        builder = ContextBuilder(engine)
+        context = builder.build_context(include_recent=0, include_relevant=0)
+
+        assert context == ""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -145,7 +145,11 @@ class TestFullIntegration:
         # Import here to avoid circular dependency
         from core.context_builder import ContextBuilder
 
-        builder = ContextBuilder(memory_engine, max_context_length=1000)
+        builder = ContextBuilder(
+            memory_engine,
+            max_context_length=1000,
+            profile_query="Jeremy wife Ashley kids dogs age",
+        )
 
         # Build context for Python-related query
         context = builder.build_context(

--- a/tests/test_openai_integration.py
+++ b/tests/test_openai_integration.py
@@ -27,7 +27,9 @@ class TestOpenAIIntegration:
         assert integration.memory_engine == memory_engine
         mock_openai.assert_called_once_with(api_key="test-key")
         mock_embeddings.assert_called_once_with("test-key", "text-embedding-3-small")
-        mock_context_builder.assert_called_once_with(memory_engine)
+        mock_context_builder.assert_called_once_with(
+            memory_engine, profile_query="Jeremy wife Ashley kids dogs age"
+        )
 
     @patch("integrations.openai_integration.OpenAI")
     @patch("integrations.openai_integration.OpenAIEmbeddings")


### PR DESCRIPTION
## Summary
- Allow `ContextBuilder` to fetch optional profile memories via a new `profile_query` parameter
- Avoid duplicate FAISS entries when reloading memories
- Use direct OpenAI fallback when LangGraph is unavailable and wire profile query through OpenAI integration
- Extend tests for profile memory inclusion/exclusion and updated integrations

## Testing
- `pytest tests/test_context_builder.py -q`
- `pytest tests/test_openai_integration.py -q`
- `pytest tests/test_integration.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'storage.mock_store'; ImportError: cannot import name 'get_openai_integration')*


------
https://chatgpt.com/codex/tasks/task_e_68996292e9ec8333bf7a74f7e43d3a79