### PR TITLE
Centralize timestamp parsing helper

### DIFF
--- a/core/memory_engine.py
+++ b/core/memory_engine.py
@@ -36,6 +36,7 @@ import json
 import os
 from pathlib import Path
 from .logging_config import get_logger, log_memory_operation, monitor_performance
+from .utils import parse_timestamp
 
 
 @dataclass
@@ -72,7 +73,7 @@ class Memory:
         return cls(
             content=data.get("content", data.get("text", "")),  # Support 'text' field
             metadata=data.get("metadata", {}),
-            timestamp=datetime.fromisoformat(data["timestamp"]) if isinstance(data.get("timestamp"), str) else data.get("timestamp", datetime.now()),
+            timestamp=parse_timestamp(data.get("timestamp")) if isinstance(data.get("timestamp"), str) else data.get("timestamp", datetime.now()),
             relevance_score=data.get("relevance_score", 0.0),
             role=data.get("role", "user"),
             thread_id=data.get("thread_id"),

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from typing import Optional
+
+
+def parse_timestamp(timestamp_str: Optional[str]) -> datetime:
+    """Parse timestamp string in ISO-8601 or Unix format.
+
+    Args:
+        timestamp_str: Timestamp as ISO-8601 string or Unix seconds.
+
+    Returns:
+        Parsed ``datetime`` without timezone information. If parsing fails or
+        ``timestamp_str`` is ``None``, the current time is returned.
+    """
+    if not timestamp_str:
+        return datetime.now()
+
+    try:
+        if 'T' in timestamp_str:
+            return datetime.fromisoformat(timestamp_str.replace('Z', '+00:00')).replace(tzinfo=None)
+        return datetime.fromtimestamp(float(timestamp_str))
+    except Exception:
+        return datetime.now()

--- a/optimized_memory_engine.py
+++ b/optimized_memory_engine.py
@@ -16,6 +16,7 @@ from core.memory_engine import Memory, MemoryEngine
 from integrations.embeddings import EmbeddingProvider
 from storage.vector_store import VectorStore
 from core.logging_config import get_logger, monitor_performance
+from core.utils import parse_timestamp
 
 logger = get_logger(__name__)
 
@@ -126,8 +127,8 @@ class OptimizedMemoryEngine(MemoryEngine):
         
         for i, mem_data in enumerate(batch):
             try:
-                # Parse timestamp efficiently
-                timestamp = self._parse_timestamp(mem_data.get('timestamp'))
+                # Parse timestamp
+                timestamp = parse_timestamp(mem_data.get('timestamp'))
                 
                 # Create Memory object without embedding
                 memory = Memory(
@@ -151,21 +152,6 @@ class OptimizedMemoryEngine(MemoryEngine):
                 continue
         
         return memories
-    
-    def _parse_timestamp(self, timestamp_str: Optional[str]) -> datetime:
-        """Parse timestamp string efficiently"""
-        if not timestamp_str:
-            return datetime.now()
-        
-        try:
-            if 'T' in timestamp_str:
-                # ISO format
-                return datetime.fromisoformat(timestamp_str.replace('Z', '+00:00')).replace(tzinfo=None)
-            else:
-                # Unix timestamp
-                return datetime.fromtimestamp(float(timestamp_str))
-        except:
-            return datetime.now()
     
     def _verify_faiss_alignment(self):
         """Verify alignment between memories and FAISS index"""

--- a/optimized_memory_loader.py
+++ b/optimized_memory_loader.py
@@ -19,6 +19,7 @@ from integrations.embeddings import OpenAIEmbeddings
 from storage.faiss_store import FaissVectorStore
 from dotenv import load_dotenv
 import logging
+from core.utils import parse_timestamp
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -88,20 +89,8 @@ class OptimizedMemoryLoader:
         for i, mem_data in enumerate(memory_data):
             try:
                 # Parse timestamp
-                timestamp_str = mem_data.get('timestamp')
-                if timestamp_str:
-                    try:
-                        # Handle various timestamp formats
-                        if 'T' in timestamp_str:
-                            timestamp = datetime.fromisoformat(timestamp_str.replace('Z', '+00:00'))
-                        else:
-                            timestamp = datetime.fromtimestamp(float(timestamp_str))
-                        timestamp = timestamp.replace(tzinfo=None)  # Remove timezone for consistency
-                    except:
-                        timestamp = datetime.now()
-                else:
-                    timestamp = datetime.now()
-                
+                timestamp = parse_timestamp(mem_data.get('timestamp'))
+
                 # Create Memory object without embedding (will use FAISS index)
                 memory = Memory(
                     content=mem_data.get('content', ''),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from core.utils import parse_timestamp
+
+
+def test_parse_timestamp_iso():
+    ts = parse_timestamp("2023-01-01T12:00:00Z")
+    assert ts == datetime(2023, 1, 1, 12, 0, 0)
+
+
+def test_parse_timestamp_unix():
+    unix = 1700000000
+    ts = parse_timestamp(str(unix))
+    assert ts == datetime.fromtimestamp(unix)
+
+
+def test_parse_timestamp_invalid():
+    before = datetime.now()
+    ts = parse_timestamp("invalid")
+    after = datetime.now()
+    assert before <= ts <= after


### PR DESCRIPTION
## Summary
- add core.utils.parse_timestamp for ISO-8601 and Unix timestamps
- replace inline parsing in memory engines/loaders with helper
- test parse_timestamp across multiple timestamp formats

## Testing
- `pytest` *(fails: 4 errors during collection)*
- `pytest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6899628c96808333b7a4b07560cc7830