### PR TITLE
Add personality trait support to chat responses

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -25,6 +25,16 @@ class MemoryResponse(BaseModel):
     relevance_score: float = 0.0
 
 
+class PersonalityTraits(BaseModel):
+    """Big Five personality traits on a 0-1 scale."""
+
+    extraversion: float = Field(0.5, ge=0.0, le=1.0)
+    agreeableness: float = Field(0.5, ge=0.0, le=1.0)
+    conscientiousness: float = Field(0.5, ge=0.0, le=1.0)
+    neuroticism: float = Field(0.5, ge=0.0, le=1.0)
+    openness: float = Field(0.5, ge=0.0, le=1.0)
+
+
 class ChatRequest(BaseModel):
     """Schema for chat requests"""
 
@@ -41,6 +51,10 @@ class ChatRequest(BaseModel):
     )
     thread_id: str = Field(
         "default", description="Conversation thread ID for maintaining context"
+    )
+    personality: Optional[PersonalityTraits] = Field(
+        None,
+        description="Optional Big Five personality profile to influence response style",
     )
 
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,6 @@
 from .memory_engine import MemoryEngine
 from .context_builder import ContextBuilder
+from .personality import PersonalityProfile
 
-__all__ = ["MemoryEngine", "ContextBuilder"]
+__all__ = ["MemoryEngine", "ContextBuilder", "PersonalityProfile"]
 __version__ = "0.1.0"

--- a/core/personality.py
+++ b/core/personality.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+@dataclass
+class PersonalityProfile:
+    """Simple Big Five personality model for response style control."""
+
+    extraversion: float = 0.5
+    agreeableness: float = 0.5
+    conscientiousness: float = 0.5
+    neuroticism: float = 0.5
+    openness: float = 0.5
+
+    def to_prompt(self) -> str:
+        """Return a system prompt snippet describing the personality profile."""
+        return (
+            "Adopt a personality with these Big Five trait levels (0-1 scale): "
+            f"extraversion {self.extraversion:.2f}, "
+            f"agreeableness {self.agreeableness:.2f}, "
+            f"conscientiousness {self.conscientiousness:.2f}, "
+            f"neuroticism {self.neuroticism:.2f}, "
+            f"openness {self.openness:.2f}. "
+            "Adjust tone and phrasing accordingly."
+        )

--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch, Mock
+from integrations.direct_openai import DirectOpenAIChat
+from core.personality import PersonalityProfile
+
+
+def test_personality_prompt_included(memory_engine):
+    with patch("integrations.direct_openai.OpenAI") as mock_openai, \
+         patch("integrations.direct_openai.OpenAIEmbeddings") as mock_embeddings:
+        mock_openai.return_value = Mock()
+        mock_embeddings.return_value = Mock()
+        chat = DirectOpenAIChat(api_key="test", memory_engine=memory_engine)
+        profile = PersonalityProfile(
+            extraversion=0.8,
+            agreeableness=0.2,
+            conscientiousness=0.9,
+            neuroticism=0.1,
+            openness=0.7,
+        )
+        messages = chat._build_messages_array(
+            thread_id="t1",
+            user_message="Hello",
+            include_memories=0,
+            personality=profile,
+        )
+        assert any(
+            "extraversion 0.80" in m["content"] for m in messages if m["role"] == "system"
+        )


### PR DESCRIPTION
## Summary
- introduce `PersonalityProfile` to represent Big Five traits
- allow API chat requests to include optional personality traits
- inject personality guidance into DirectOpenAIChat message building
- add unit test validating personality prompt insertion

## Testing
- `pytest tests/test_personality.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'integrations.mock_embeddings' and No module named 'langchain')*


------
https://chatgpt.com/codex/tasks/task_e_689b3cdd20b083339ae7eeda950413bb